### PR TITLE
Hwi single finger test

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,14 @@ colcon build
 ros2 launch hardware hardware.launch.py use_mock_hardware:=true
 ```
 
+### Running Single Finger Test
+1. First, ensure that you set the test variables `num_on_commands` and `command_period` which sets the number of key presses you would like and the period to send the messages, respectively.
+
+2. Launch the test executable.
+```sh
+ros2 run hardware single_finger_test
+```
+
 ## Troubleshooting
 
 ### I2C Errors

--- a/src/hardware/CMakeLists.txt
+++ b/src/hardware/CMakeLists.txt
@@ -93,6 +93,16 @@ if(BUILD_TESTING)
   target_link_libraries(${PROJECT_NAME}_robotic_controller_performance_metric ${PROJECT_NAME})
 endif()
 
+add_executable(single_finger_test test/single_finger_test.cpp)
+ament_target_dependencies(single_finger_test 
+  rclcpp 
+  rclcpp_action 
+  control_msgs 
+  trajectory_msgs
+)
+install(TARGETS single_finger_test DESTINATION lib/${PROJECT_NAME})
+
+
 # Add an executable to the project using the specified source files
 add_executable(example_jtc examples/example_jtc.cpp)
 ament_target_dependencies(example_jtc

--- a/src/hardware/test/single_finger_test.cpp
+++ b/src/hardware/test/single_finger_test.cpp
@@ -1,0 +1,115 @@
+#include <rclcpp/rclcpp.hpp>
+#include <rclcpp_action/rclcpp_action.hpp>
+#include <control_msgs/action/follow_joint_trajectory.hpp>
+#include <trajectory_msgs/msg/joint_trajectory_point.hpp>
+#include <chrono>
+#include <thread>
+#include <vector>
+#include <string>
+
+using FollowJointTrajectory = control_msgs::action::FollowJointTrajectory;
+using GoalHandle = rclcpp_action::ClientGoalHandle<FollowJointTrajectory>;
+
+// Number of "ON" commands (each "ON" is followed by an "OFF")
+constexpr int num_on_commands = 280;
+constexpr double command_period = 0.05;
+
+class RapidCommandTest : public rclcpp::Node {
+public:
+  RapidCommandTest()
+  : Node("single_finger_test"), on_count_(0), toggle_(false), test_completed_(false)
+  {
+    joint_client_ = rclcpp_action::create_client<FollowJointTrajectory>(
+      this, "/left_hand_controller/follow_joint_trajectory");
+
+    while (!joint_client_->wait_for_action_server(std::chrono::seconds(2))) {
+      RCLCPP_WARN(this->get_logger(), "Waiting for action server...");
+    }
+
+    RCLCPP_INFO(this->get_logger(), "Action server available. Starting test...");
+    start_time_ = this->now();
+    send_command();
+  }
+
+private:
+  rclcpp_action::Client<FollowJointTrajectory>::SharedPtr joint_client_;
+  rclcpp::Time start_time_;
+  size_t on_count_;
+  bool toggle_;
+  bool test_completed_;
+
+  static constexpr double servo_center   = 0.0;
+
+  // Based on URDF geometry of 0.2 -> -0.2 for finger position range.
+  // The value of 0.15 was found empirically to coincide with a 15 degree angle for the servo used for testing
+  static constexpr double servo_left = 0.15; 
+  static constexpr double solenoid_off = 0.0;
+  static constexpr double solenoid_on  = 1.0;
+
+  void send_command() {
+    if (on_count_ >= num_on_commands && !test_completed_) {
+      RCLCPP_INFO(this->get_logger(), "Test completed. Sending final OFF command...");
+      test_completed_ = true;
+      send_final_off_command();
+      return;
+    }
+
+    double target_servo = toggle_ ? servo_center : servo_left;
+    double target_solenoid = toggle_ ? solenoid_on : solenoid_off;
+
+    auto goal_msg = FollowJointTrajectory::Goal();
+    goal_msg.trajectory.joint_names = {"left_hand_thumb_servo_joint", "left_hand_thumb_solenoid_joint"};
+
+    trajectory_msgs::msg::JointTrajectoryPoint point;
+    point.positions = {target_servo, target_solenoid};
+    point.time_from_start = rclcpp::Duration::from_seconds(command_period);
+    goal_msg.trajectory.points.push_back(point);
+
+    auto send_goal_options = rclcpp_action::Client<FollowJointTrajectory>::SendGoalOptions();
+    send_goal_options.result_callback = [this, target_servo, target_solenoid](const GoalHandle::WrappedResult &result) {
+      if (result.code == rclcpp_action::ResultCode::SUCCEEDED) {
+        RCLCPP_INFO(this->get_logger(), "Command %zu succeeded: Servo=%.2f, Solenoid=%.2f", on_count_, target_servo, target_solenoid);
+      } else {
+        RCLCPP_ERROR(this->get_logger(), "Command %zu failed", on_count_);
+      }
+
+      if (toggle_) {
+        on_count_++;
+      }
+      toggle_ = !toggle_;
+      std::this_thread::sleep_for(std::chrono::milliseconds(static_cast<int>(command_period * 1000)));
+      send_command();
+    };
+
+    joint_client_->async_send_goal(goal_msg, send_goal_options);
+  }
+
+  void send_final_off_command() {
+    auto goal_msg = FollowJointTrajectory::Goal();
+    goal_msg.trajectory.joint_names = {"left_hand_thumb_servo_joint", "left_hand_thumb_solenoid_joint"};
+
+    trajectory_msgs::msg::JointTrajectoryPoint point;
+    point.positions = {servo_center, solenoid_off};
+    point.time_from_start = rclcpp::Duration::from_seconds(command_period);
+    goal_msg.trajectory.points.push_back(point);
+
+    auto send_goal_options = rclcpp_action::Client<FollowJointTrajectory>::SendGoalOptions();
+    send_goal_options.result_callback = [this](const GoalHandle::WrappedResult &result) {
+      if (result.code == rclcpp_action::ResultCode::SUCCEEDED) {
+        RCLCPP_INFO(this->get_logger(), "Final OFF command executed successfully.");
+      } else {
+        RCLCPP_ERROR(this->get_logger(), "Final OFF command failed.");
+      }
+    };
+
+    joint_client_->async_send_goal(goal_msg, send_goal_options);
+  }
+};
+
+int main(int argc, char **argv) {
+  rclcpp::init(argc, argv);
+  auto node = std::make_shared<RapidCommandTest>();
+  rclcpp::spin(node);
+  rclcpp::shutdown();
+  return 0;
+}


### PR DESCRIPTION
This is just a simple test that will deliver a number of commands to the HWI. It runs both the servo and solenoid commands simultaneously and moves them from their default position (0 for both components) to their terminal positions. The speed at which the commands are sent is defined by a period variable in the code.

The test will run the number of times specified in the code and it will end in an OFF state. 
The logging for this test was done separately on an arduino, this test is simply to actuate the components.

Note: For this test the angle required for the servo to reach its terminal position was determined to be 0.15 (position) empirically, this may need to be adjusted if you are using a different servo when running the test.

### Running Single Finger Test
1. First, ensure that you set the test variables `num_on_commands` and `command_period` which sets the number of key presses you would like and the period to send the messages, respectively.

2. Launch the test executable.
```sh
ros2 run hardware single_finger_test
```